### PR TITLE
add AWS profile before eks update-kubeconfig

### DIFF
--- a/EKS-Cluster/ekscluster.tf
+++ b/EKS-Cluster/ekscluster.tf
@@ -62,6 +62,7 @@ resource "null_resource" "local_k8s_context" {
   depends_on = [time_sleep.wait_for_kube]
   provisioner "local-exec" {
     # Update your local eks and kubectl credentials for the newly created cluster
-    command = "for i in 1 2 3 4 5; do aws eks --region ${var.region}  update-kubeconfig --name ${aws_eks_cluster.aws_eks.name} && break || sleep 60; done"
+    command = "export AWS_DEFAULT_PROFILE=${var.profile}; for i in 1 2 3 4 5; do aws eks --region ${var.region}  update-kubeconfig --name ${aws_eks_cluster.aws_eks.name} && break || sleep 60; done"    
   }
 }
+


### PR DESCRIPTION
When a user have more than one AWS profile the "eks update-kubeconfig" is failing because it always use the default. As a result, the cluster is created but kubectl context is not configured. Setting the profile name in the AWS_DEFAULT_PROFILE fixed the problem. 